### PR TITLE
Supports db/image config option for PostgreSQL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.0.0-RC5
+- Supports optional "image" setting in "db" config for PostgreSQL containers only. The "image" setting can specify a custom Docker image name/tag for the database container.
+
 ## v1.0.0-RC4
 
 - Fixed bug where `dup up` on an "uninitialised" project that has `"type": "none"` would fail

--- a/src/command.nim
+++ b/src/command.nim
@@ -110,7 +110,7 @@ proc up*(conf: ProjectConfig) {.raises: [].} =
     startMysql(conf)
     startWeb(conf.name, conf.port, conf.volume, conf.envVars, true)
   of PostgreSQL:
-    startPostgres(conf.name, conf.dbConf.name, conf.dbConf.username, conf.dbConf.password, conf.dbConf.image)
+    startPostgres(conf)
     startWeb(conf.name, conf.port, conf.volume, conf.envVars, true)
   of MongoDB:
     startMongo(conf)

--- a/src/command.nim
+++ b/src/command.nim
@@ -110,7 +110,7 @@ proc up*(conf: ProjectConfig) {.raises: [].} =
     startMysql(conf)
     startWeb(conf.name, conf.port, conf.volume, conf.envVars, true)
   of PostgreSQL:
-    startPostgres(conf.name, conf.dbConf.name, conf.dbConf.username, conf.dbConf.password)
+    startPostgres(conf.name, conf.dbConf.name, conf.dbConf.username, conf.dbConf.password, conf.dbConf.image)
     startWeb(conf.name, conf.port, conf.volume, conf.envVars, true)
   of MongoDB:
     startMongo(conf)

--- a/src/container.nim
+++ b/src/container.nim
@@ -76,13 +76,12 @@ proc startMysql*(conf: ProjectConfig) =
     quit(exitCode)
   writeSuccess("MySQL started, and exposed on host port " & $chosenPort)
 
-proc startPostgres*(project: string, dbname: string, dbuser: string,
-                    dbpass: string, image: string) {.raises: [].} =
+proc startPostgres*(conf: ProjectConfig) {.raises: [].} =
   writeMsg("Starting Postgres...")
   let
     chosenPort = getAndCheckRandomPort()
     portFragment = $chosenPort & ":5432"
-    command = "docker run -d --name " & project & "-db --volumes-from " & project & "-data -e POSTGRES_PASSWORD=" & dbpass & " -e POSTGRES_DB=" & dbname & " -e POSTGRES_USER=" & dbuser & " -p " & portFragment & " " & image
+    command = "docker run -d --name " & conf.db & " --volumes-from " & conf.data & " -e POSTGRES_PASSWORD=" & conf.dbConf.password & " -e POSTGRES_DB=" & conf.dbConf.name & " -e POSTGRES_USER=" & conf.dbConf.username & " -p " & portFragment & " " & conf.dbConf.getImageName()
   writeCmd(command)
   let exitCode = execCmd command
   if exitCode != 0:

--- a/src/container.nim
+++ b/src/container.nim
@@ -76,7 +76,7 @@ proc startMysql*(conf: ProjectConfig) =
     quit(exitCode)
   writeSuccess("MySQL started, and exposed on host port " & $chosenPort)
 
-proc startPostgresCommand*(conf: ProjectConfig, port: int): string {raises: [], noSideEffect.} =
+proc startPostgresCommand*(conf: ProjectConfig, port: int): string {.raises: [], noSideEffect.} =
   ## Builds the command used to start PostgreSQL database containers
   ## Quotes the configuration passed into the command construction
   result = join([

--- a/src/container.nim
+++ b/src/container.nim
@@ -77,12 +77,12 @@ proc startMysql*(conf: ProjectConfig) =
   writeSuccess("MySQL started, and exposed on host port " & $chosenPort)
 
 proc startPostgres*(project: string, dbname: string, dbuser: string,
-                    dbpass: string) {.raises: [].} =
+                    dbpass: string, image: string) {.raises: [].} =
   writeMsg("Starting Postgres...")
   let
     chosenPort = getAndCheckRandomPort()
     portFragment = $chosenPort & ":5432"
-    command = "docker run -d --name " & project & "-db --volumes-from " & project & "-data -e POSTGRES_PASSWORD=" & dbpass & " -e POSTGRES_DB=" & dbname & " -e POSTGRES_USER=" & dbuser & " -p " & portFragment & " postgres:9.5"
+    command = "docker run -d --name " & project & "-db --volumes-from " & project & "-data -e POSTGRES_PASSWORD=" & dbpass & " -e POSTGRES_DB=" & dbname & " -e POSTGRES_USER=" & dbuser & " -p " & portFragment & " " & image
   writeCmd(command)
   let exitCode = execCmd command
   if exitCode != 0:

--- a/src/database.nim
+++ b/src/database.nim
@@ -25,7 +25,8 @@ proc newDBConfig*(config: JsonNode): DatabaseConfig {.raises: [DBConfigError].} 
     result = PostgreSQL.newDBConfig(
       config.getOrDefault("pass").getStr(),
       config.getOrDefault("name").getStr(),
-      config.getOrDefault("user").getStr())
+      config.getOrDefault("user").getStr(),
+      config.getOrDefault("image").getStr("postgres:9.5"))
   of "mongodb":
     result = MongoDB.newDBConfig()
   of "none":

--- a/src/database.nim
+++ b/src/database.nim
@@ -26,7 +26,7 @@ proc newDBConfig*(config: JsonNode): DatabaseConfig {.raises: [DBConfigError].} 
       config.getOrDefault("pass").getStr(),
       config.getOrDefault("name").getStr(),
       config.getOrDefault("user").getStr(),
-      config.getOrDefault("image").getStr("postgres:9.5"))
+      config.getOrDefault("image").getStr())
   of "mongodb":
     result = MongoDB.newDBConfig()
   of "none":
@@ -52,7 +52,7 @@ proc getImageName*(conf: DatabaseConfig): string {.raises: [].} =
   of MySQL:
     result = "tutum/mysql"
   of PostgreSQL:
-    result = "postgres:9.5"
+    result = if conf.image == "": "postgres:9.5" else: conf.image
   of MongoDB:
     result = "mongo:3.3"
   of None:

--- a/src/private/types.nim
+++ b/src/private/types.nim
@@ -13,6 +13,7 @@ type
     case kind: DatabaseType
     of PostgreSQL:
       username*: string
+      image*: string
     else: discard
     # Shared properties across the ADT -- empty for None et al.
     name*: string
@@ -40,17 +41,19 @@ proc newDBMySQL(pass: string, name: string): DatabaseConfig
     password: pass,
     name: name)
 
-proc newDBPostgreSQL(pass: string, name: string, user: string): DatabaseConfig
+proc newDBPostgreSQL(pass: string, name: string, user: string, image: string): DatabaseConfig
                      {.raises: [DBConfigError].} =
   ## Creates a new DatabaseConfig of the "PostgreSQL" type
   if pass.len == 0: raise newException(DBConfigError, "'pass' must be set and non-empty")
   if name.len == 0: raise newException(DBConfigError, "'name' must be set and non-empty")
   if user.len == 0: raise newException(DBConfigError, "'user' must be set and non-empty")
+  if image.len == 0: raise newException(DBConfigError, "'image' must be set and non-empty")
   result = DatabaseConfig(
     kind: PostgreSQL,
     password: pass,
     name: name,
-    username: user)
+    username: user,
+    image: image)
 
 proc newDBMongoDB*(): DatabaseConfig {.raises: [].} =
   result = DatabaseConfig(
@@ -59,13 +62,13 @@ proc newDBMongoDB*(): DatabaseConfig {.raises: [].} =
     name: "")
 
 proc newDBConfig*(dbType: DatabaseType, pass = "", name = "",
-                  user = ""): DatabaseConfig {.raises: [DBConfigError].} =
+                  user = "", image = ""): DatabaseConfig {.raises: [DBConfigError].} =
   ## Creates a new database configuration based on a given type param
   case dbType
   of MySQL:
     result = newDBMySQL(pass, name)
   of PostgreSQL:
-    result = newDBPostgreSQL(pass, name, user)
+    result = newDBPostgreSQL(pass, name, user, image)
   of MongoDB:
     result = newDBMongoDB()
   of None:

--- a/src/private/types.nim
+++ b/src/private/types.nim
@@ -47,7 +47,6 @@ proc newDBPostgreSQL(pass: string, name: string, user: string, image: string): D
   if pass.len == 0: raise newException(DBConfigError, "'pass' must be set and non-empty")
   if name.len == 0: raise newException(DBConfigError, "'name' must be set and non-empty")
   if user.len == 0: raise newException(DBConfigError, "'user' must be set and non-empty")
-  if image.len == 0: raise newException(DBConfigError, "'image' must be set and non-empty")
   result = DatabaseConfig(
     kind: PostgreSQL,
     password: pass,


### PR DESCRIPTION
Currently for PostgreSQL database containers only, supports an optional "image" setting under the "db" settings in a project's .up.json.

The "image" setting can specify a custom Docker image and tag (eg "studionone/postgres:9.5").

This setting is optional. If not specified, the default of "postgres:9.5" (the official PostgreSQL 9.5 image) used, as before.
