### PR TITLE
Fixes incorrect default VIRTUAL_HOST variable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.4
+
+- Fixes incorrect `VIRTUAL_HOST` env-var for the web-container when using the default
+
 ## v1.0.3
 
 - Removes the bindings between `VIRTUAL_HOST` and `hostname` (`-h` in the `docker run`) for the web container. This fixes the incorrect hostname format when a composite `VIRTUAL_HOST` is passed in via `env`

--- a/dup.nimble
+++ b/dup.nimble
@@ -1,6 +1,6 @@
 [Package]
 name          = "dup"
-version       = "1.0.3"
+version       = "1.0.4"
 author        = "Josh Girvin <josh@jgirvin.com>, Nathan Craike <me@ncraike.com>"
 description   = "CLI wrapper for local Docker web development"
 license       = "MIT"

--- a/src/container.nim
+++ b/src/container.nim
@@ -141,7 +141,7 @@ proc startWebCmd*(conf: ProjectConfig, hasDb: bool = true): string {.raises: [],
     folder = "-v $PWD/code:/var/www"
   var vhostEnv = ""
   if vhost == "":
-    vhostEnv = "-e VIRTUAL_HOST=" & quoteShellPosix(vhost)
+    vhostEnv = "-e VIRTUAL_HOST=" & quoteShellPosix(hostname)
 
   result = join([
     "docker run",

--- a/src/dup.nim
+++ b/src/dup.nim
@@ -13,7 +13,7 @@ from database import newDBConfig
 from container import checkDockerfile, checkAndParseDupFile
 
 ## Define our version constant for re-use
-const version = "dup 1.0.3"
+const version = "dup 1.0.4"
 
 ## Define our docopt parsing schema
 let doc = """


### PR DESCRIPTION
Accidentally used the *empty* `vhost` variable as the default `VIRTUAL_HOST` instead of `hostname`