### PR TITLE
Allows Dup to run with Docker 1.13.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.5
+
+- Allows using Dup with Docker 1.13.x.
+
 ## v1.0.4
 
 - Fixes incorrect `VIRTUAL_HOST` env-var for the web-container when using the default

--- a/dup.nimble
+++ b/dup.nimble
@@ -1,6 +1,6 @@
 [Package]
 name          = "dup"
-version       = "1.0.4"
+version       = "1.0.5"
 author        = "Josh Girvin <josh@jgirvin.com>, Nathan Craike <me@ncraike.com>"
 description   = "CLI wrapper for local Docker web development"
 license       = "MIT"

--- a/src/dup.nim
+++ b/src/dup.nim
@@ -13,7 +13,7 @@ from database import newDBConfig
 from container import checkDockerfile, checkAndParseDupFile
 
 ## Define our version constant for re-use
-const version = "dup 1.0.4"
+const version = "dup 1.0.5"
 
 ## Define our docopt parsing schema
 let doc = """
@@ -47,10 +47,10 @@ var
   dbConf = newDBConfig(None) ## Default the database config to "None"
   conf: ProjectConfig ## Configuration ref object
 
-## Check Docker version, bail-out if it's not 1.12.x
+## Check Docker version, bail-out if it's not 1.12.x or 1.13.x
 let
   dv = docker.getVersion()
-  isWrong = if dv.major == 1 and dv.minor == 12: false else: true
+  isWrong = if dv.major == 1 and (dv.minor == 12 or dv.minor == 13): false else: true
 if isWrong:
   writeError("Please install Docker >= v1.12.0", true)
   quit(5)


### PR DESCRIPTION
Dup will now run with Docker versions 1.12.x OR 1.13.x.

I've tested the built result with my local Docker 1.13.x, running `dup up`, `dup status`, `dup build` and `dup init`. No problems so far.